### PR TITLE
Replace passages with reflection questions in daily message

### DIFF
--- a/scripts/seed-all.ts
+++ b/scripts/seed-all.ts
@@ -109,7 +109,7 @@ interface SeedReading {
   date: string;
   book: string;
   chapter: string;
-  passages: string[];
+  reflection_questions?: string[];
   esv_link?: string;
 }
 
@@ -142,7 +142,7 @@ async function seedReadingPlans(readings: SeedReading[]) {
         date: reading.date,
         book: reading.book,
         chapter: reading.chapter,
-        passages: reading.passages,
+        reflection_questions: reading.reflection_questions || [],
         esv_link: reading.esv_link || null
       });
 

--- a/src/lib/supabase-message-composer.ts
+++ b/src/lib/supabase-message-composer.ts
@@ -88,32 +88,24 @@ export async function composeDailyMessage(): Promise<string | null> {
   
   // Generate or use custom ESV link
   const esvLink = reading.esv_link || generateESVLink(reading.book, reading.chapter);
-  
-  // Format passages
-  let passagesFormatted = '';
-  if (reading.passages && reading.passages.length > 0) {
-    if (reading.passages.length === 1) {
-      passagesFormatted = `📝 ${reading.passages[0]}`;
-    } else {
-      passagesFormatted = '📝 Today\'s passages:\n' + 
-        reading.passages.map(p => `  • ${p}`).join('\n');
-    }
+
+  let bottomSection = '';
+  if (reading.reflection_questions && reading.reflection_questions.length > 0) {
+    const questions = reading.reflection_questions.map(q => `• ${q}`).join('\n');
+    bottomSection = `💭 *Reflection Questions*\n${questions}`;
+  } else if (encouragement) {
+    bottomSection = `💝 *Daily Encouragement*\n${encouragement.message}`;
   }
-  
-  const encouragementText = encouragement 
-    ? `💝 *Daily Encouragement*\n${encouragement.message}`
-    : '';
-  
+
   const message = `
 📖 *Today's Bible Reading*
 📅 ${new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}
 
 📚 *${reading.book} ${reading.chapter}*
-${passagesFormatted}
 
 🔗 *Read on ESV:* [Click here to read](${esvLink})
 
-${encouragementText}
+${bottomSection}
 
 _Have a blessed day! 🙏_
   `;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -25,7 +25,7 @@ export interface DBReading {
   date: string;
   book: string;
   chapter: string;
-  passages: string[];
+  reflection_questions: string[];
   esv_link: string | null;
   created_at: string;
   updated_at: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,8 +2,7 @@ export interface BibleReading {
     date: string;
     book: string;
     chapter: string;
-    passages: string[]; // Array of passage titles for the chapter(s)
-    esvLink?: string; // Optional custom link
+    esvLink?: string;
 }
 
 export interface Encouragement {

--- a/supabase/migrations/20260516045135_add_reflection_questions.sql
+++ b/supabase/migrations/20260516045135_add_reflection_questions.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."reading_plans"
+  ADD COLUMN "reflection_questions" text[] NOT NULL DEFAULT '{}';

--- a/supabase/migrations/20260516045447_drop_passages_column.sql
+++ b/supabase/migrations/20260516045447_drop_passages_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."reading_plans"
+  DROP COLUMN "passages";

--- a/supabase/schemas/0003_add_reflection_questions.sql
+++ b/supabase/schemas/0003_add_reflection_questions.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."reading_plans"
+  ADD COLUMN "reflection_questions" text[] NOT NULL DEFAULT '{}';

--- a/supabase/schemas/0004_drop_passages_column.sql
+++ b/supabase/schemas/0004_drop_passages_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."reading_plans"
+  DROP COLUMN "passages";


### PR DESCRIPTION
- Drop passages column from reading_plans (migration + schema)
- Add reflection_questions text[] column to reading_plans
- Update message composer to show reflection questions when available, fall back to daily encouragement
- Update DBReading type, BibleReading interface, and seed script accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reading plans now include reflection questions to accompany daily scripture selections.
  * Daily messages intelligently display reflection questions when available, with encouragement content as fallback.
  * Database and data structures updated to support reflection question storage and delivery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sam-DeGuzman/ryb-bot/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->