### PR TITLE
Move daily reminder cron 5 hours earlier (18:45 UTC)

### DIFF
--- a/.github/workflows/daily-bible-reminder.yml
+++ b/.github/workflows/daily-bible-reminder.yml
@@ -2,8 +2,8 @@ name: Daily Bible Reminder
 
 on:
   schedule:
-    # Runs at 11:45 PM UTC (7:45 AM PHT) every day
-    - cron: '45 23 * * *'
+    # Runs at 6:45 PM UTC (2:45 AM PHT) every day
+    - cron: '45 18 * * *'
   workflow_dispatch: # Allow manual triggering for testing
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the scheduled delivery time for daily reminders from 23:45 UTC to 18:45 UTC.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sam-DeGuzman/ryb-bot/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->